### PR TITLE
fix: make store in memory and file persistence

### DIFF
--- a/client/client_mgr.go
+++ b/client/client_mgr.go
@@ -91,7 +91,7 @@ func (cm *Mgr) GetPeerInfoFirstVal(address string) (*pactus.PeerInfo, error) {
 
 		if networkInfo != nil {
 			for _, p := range networkInfo.ConnectedPeers {
-				for i, addr := range p.ConsensusKeys {
+				for i, addr := range p.ConsensusAddress {
 					if addr == address {
 						if i != 0 {
 							return nil, errors.New("please enter the first validator address")

--- a/store/interface.go
+++ b/store/interface.go
@@ -1,23 +1,16 @@
 package store
 
-type ClaimTransaction struct {
-	TxID   string  `json:"transaction_id"`
-	Amount float64 `json:"amount"`
-	Time   int64   `json:"time"`
-}
-
 type Claimer struct {
-	DiscordID string `json:"did"`
-	// ValAddr          string            `json:"main_net_validator_address"`
-	TotalReward      float64           `json:"r"`
-	ClaimTransaction *ClaimTransaction `json:"claim_transaction"`
+	DiscordID   string `json:"did"`
+	TotalReward int64  `json:"r"`
+	ClaimedTxID string `json:"tx_id"`
 }
 
 func (c *Claimer) IsClaimed() bool {
-	return c.ClaimTransaction != nil
+	return c.ClaimedTxID != ""
 }
 
 type IStore interface {
 	ClaimerInfo(testNetValAddr string) *Claimer
-	AddClaimTransaction(amount float64, time int64, txID, discordID, testNetValAddr string) error
+	AddClaimTransaction(testNetValAddr string, txID string) error
 }

--- a/store/mock.go
+++ b/store/mock.go
@@ -39,17 +39,17 @@ func (m *MockIStore) EXPECT() *MockIStoreMockRecorder {
 }
 
 // AddClaimTransaction mocks base method.
-func (m *MockIStore) AddClaimTransaction(amount float64, time int64, txID, discordID, testNetValAddr string) error {
+func (m *MockIStore) AddClaimTransaction(testNetValAddr, txID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddClaimTransaction", amount, time, txID, discordID, testNetValAddr)
+	ret := m.ctrl.Call(m, "AddClaimTransaction", testNetValAddr, txID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddClaimTransaction indicates an expected call of AddClaimTransaction.
-func (mr *MockIStoreMockRecorder) AddClaimTransaction(amount, time, txID, discordID, testNetValAddr any) *gomock.Call {
+func (mr *MockIStoreMockRecorder) AddClaimTransaction(testNetValAddr, txID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddClaimTransaction", reflect.TypeOf((*MockIStore)(nil).AddClaimTransaction), amount, time, txID, discordID, testNetValAddr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddClaimTransaction", reflect.TypeOf((*MockIStore)(nil).AddClaimTransaction), testNetValAddr, txID)
 }
 
 // ClaimerInfo mocks base method.

--- a/store/store.go
+++ b/store/store.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sync"
 
 	"github.com/kehiy/RoboPac/config"
 	"github.com/kehiy/RoboPac/log"
@@ -12,99 +11,71 @@ import (
 
 // Store is a thread-safe cache.
 type Store struct {
-	syncMap *sync.Map
-	cfg     *config.Config
-	logger  *log.SubLogger
+	claimers map[string]*Claimer
+	cfg      *config.Config
+	logger   *log.SubLogger
 }
 
-func LoadStore(cfg *config.Config, logger *log.SubLogger) (IStore, error) {
-	file, err := os.ReadFile(cfg.StorePath)
+func NewStore(cfg *config.Config, logger *log.SubLogger) (IStore, error) {
+	data, err := os.ReadFile(cfg.StorePath)
 	if err != nil {
 		return nil, fmt.Errorf("error loading data file: %w", err)
 	}
-	if len(file) == 0 {
-		ss := &Store{
-			syncMap: &sync.Map{},
-			cfg:     cfg,
-		}
-		return ss, nil
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty file: %s", cfg.StorePath)
 	}
 
-	data, err := unmarshalJSON(file)
-	if err != nil {
-		return nil, fmt.Errorf("error un-marshalling validator data: %w", err)
+	claimers := make(map[string]*Claimer)
+	if err := json.Unmarshal(data, &claimers); err != nil {
+		return nil, err
 	}
 
 	ss := &Store{
-		syncMap: data,
-		cfg:     cfg,
-		logger:  logger,
+		claimers: claimers,
+		cfg:      cfg,
+		logger:   logger,
 	}
 	return ss, nil
 }
 
-func (s *Store) ClaimerInfo(testNetValAddr string) *Claimer {
-	entry, found := s.syncMap.Load(testNetValAddr)
+func (s *Store) ClaimerInfo(testnetAddr string) *Claimer {
+	entry, found := s.claimers[testnetAddr]
 	if !found {
 		return nil
 	}
 
-	claimerInfo := entry.(*Claimer)
-	return claimerInfo
+	return entry
 }
 
-func (s *Store) AddClaimTransaction(amount float64, time int64, txID, discordID, testNetValAddr string) error {
-	s.syncMap.Store(testNetValAddr, &Claimer{
-		DiscordID: discordID,
-		ClaimTransaction: &ClaimTransaction{
-			TxID:   txID,
-			Amount: amount,
-			Time:   time,
-		},
-	})
+func (s *Store) AddClaimTransaction(testnetAddr string, txID string) error {
+	entry, found := s.claimers[testnetAddr]
+	if !found {
+		return fmt.Errorf("testnetAddr not found: %s", testnetAddr)
+	}
 
-	s.logger.Info("new claim transaction added", "discordID", discordID, "amount",
-		amount, "time", time, "txID", txID)
-
-	// save record.
-	data, err := marshalJSON(s.syncMap)
+	entry.ClaimedTxID = txID
+	err := s.save()
 	if err != nil {
-		s.logger.Panic("can't marshal json new claim transaction", "discordID", discordID, "amount",
-			amount, "time", time, "txID", txID, "err", err)
-
-		return fmt.Errorf("error marshalling validator data file: %w", err)
+		return err
 	}
 
-	if err := os.WriteFile(s.cfg.StorePath, data, 0o600); err != nil {
-		s.logger.Panic("can't write new claim transaction", "discordID", discordID, "amount",
-			amount, "time", time, "txID", txID, "err", err)
-
-		return fmt.Errorf("failed to write to %s: %w", s.cfg.StorePath, err)
-	}
+	s.logger.Info("new claim transaction added",
+		"discordID", entry.DiscordID,
+		"amount", entry.TotalReward,
+		"txID", txID)
 
 	return nil
 }
 
-func marshalJSON(m *sync.Map) ([]byte, error) {
-	tmpMap := make(map[string]*Claimer)
-
-	m.Range(func(k, v interface{}) bool {
-		tmpMap[k.(string)] = v.(*Claimer)
-		return true
-	})
-	return json.MarshalIndent(tmpMap, "  ", "  ")
-}
-
-func unmarshalJSON(data []byte) (*sync.Map, error) {
-	var tmpMap map[string]*Claimer
-	m := &sync.Map{}
-
-	if err := json.Unmarshal(data, &tmpMap); err != nil {
-		return m, err
+func (s *Store) save() error {
+	data, err := json.Marshal(s.claimers)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(s.cfg.StorePath, data, 0o600)
+	if err != nil {
+		return err
 	}
 
-	for key, value := range tmpMap {
-		m.Store(key, value)
-	}
-	return m, nil
+	return nil
 }

--- a/store/test/store_example.json
+++ b/store/test/store_example.json
@@ -10,10 +10,6 @@
   "tpc1pesz6kuv7jts6al6la3794fyj5xaj7wm93k7z6y": {
     "did": "964550933793103912",
     "r": 12,
-    "claim_transaction": {
-      "transaction_id": "",
-      "amount": 0,
-      "time": 0
-    }
+    "tx_id": "c03652ef5c0d343f92901d659be0eafbbfc35d7829a33032540b7a4ef03660b1"
   }
 }

--- a/wallet/interface.go
+++ b/wallet/interface.go
@@ -1,7 +1,7 @@
 package wallet
 
 type IWallet interface {
-	BondTransaction(string, string, string, float64) (string, error)
-	TransferTransaction(string, string, string, float64) (string, error)
+	BondTransaction(string, string, string, int64) (string, error)
+	TransferTransaction(string, string, string, int64) (string, error)
 	Address() string
 }

--- a/wallet/mock.go
+++ b/wallet/mock.go
@@ -53,7 +53,7 @@ func (mr *MockIWalletMockRecorder) Address() *gomock.Call {
 }
 
 // BondTransaction mocks base method.
-func (m *MockIWallet) BondTransaction(arg0, arg1, arg2 string, arg3 float64) (string, error) {
+func (m *MockIWallet) BondTransaction(arg0, arg1, arg2 string, arg3 int64) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BondTransaction", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(string)
@@ -68,7 +68,7 @@ func (mr *MockIWalletMockRecorder) BondTransaction(arg0, arg1, arg2, arg3 any) *
 }
 
 // TransferTransaction mocks base method.
-func (m *MockIWallet) TransferTransaction(arg0, arg1, arg2 string, arg3 float64) (string, error) {
+func (m *MockIWallet) TransferTransaction(arg0, arg1, arg2 string, arg3 int64) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransferTransaction", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(string)

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -49,13 +49,12 @@ func Open(cfg *config.Config, logger *log.SubLogger) IWallet {
 	return nil
 }
 
-func (w *Wallet) BondTransaction(pubKey, toAddress, memo string, amount float64) (string, error) {
+func (w *Wallet) BondTransaction(pubKey, toAddress, memo string, amount int64) (string, error) {
 	opts := []pwallet.TxOption{
-		pwallet.OptionFee(util.CoinToChange(0)),
 		pwallet.OptionMemo(memo),
 	}
 	tx, err := w.wallet.MakeBondTx(w.address, toAddress, pubKey,
-		util.CoinToChange(amount), opts...)
+		amount, opts...)
 	if err != nil {
 		w.logger.Error("error creating bond transaction", "err", err, "address", toAddress, "amount", amount)
 		return "", err
@@ -81,7 +80,7 @@ func (w *Wallet) BondTransaction(pubKey, toAddress, memo string, amount float64)
 	return res, nil // return transaction hash
 }
 
-func (w *Wallet) TransferTransaction(pubKey, toAddress, memo string, amount float64) (string, error) {
+func (w *Wallet) TransferTransaction(pubKey, toAddress, memo string, amount int64) (string, error) {
 	fee, err := w.wallet.CalculateFee(int64(amount), payload.TypeTransfer)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Description

This PR replaces `sync.Map` with `map`, because Bot has concurrency guard.

## Types of changes
- [x] Bug fix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (corrections, enhancements, or additions to documentation)
- [ ] Other (please describe):
